### PR TITLE
fixes to improve consistency of passing tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,7 +5,7 @@
 ],
 "viewportWidth": 1280,
 "viewportHeight": 960,
-"videoUploadOnPasses":false
-
+"videoUploadOnPasses":false,
+"defaultCommandTimeout":8000
 }
 

--- a/cypress/integration/settings_page/settings_page.js
+++ b/cypress/integration/settings_page/settings_page.js
@@ -7,7 +7,9 @@ When ('I navigate to Settings page', ()=>{
         // cy.contains('Settings').click({force: true})
     })
   Then ('It verifies Settings', ()=>{
-        cy.contains('General').click()
+        cy.location('pathname').should('eq','/settings')
+
+        cy.contains('General').should('be.visible').click()
         cy.wait(3000)
         cy.go('back')
   


### PR DESCRIPTION
- increased default timeout to 8 seconds. too long, but necessary for tests to pass.
- added a check to see when Settings page is navigated to, the right url is opened.